### PR TITLE
serve css files in dev and fix overlapping breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envoy.css",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Envoy's internal CSS framework",
   "style": "src/envoy.css",
   "watch": {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express')
 const app = express()
 
 app.use(express.static('docs'))
+app.use(express.static('css'))
 
 app.listen(3000, function () {
   console.log('Server address: http://127.0.0.1:3000/')

--- a/src/_variables.css
+++ b/src/_variables.css
@@ -93,9 +93,9 @@
   --button-background-color: var(--red);
 }
 
-@custom-media --breakpoint-xs (max-width: 30rem);
+@custom-media --breakpoint-xs (max-width: 29.999rem);
 @custom-media --breakpoint-sm (min-width: 30rem);
-@custom-media --breakpoint-sm-md (min-width: 30rem) and (max-width: 48rem);
+@custom-media --breakpoint-sm-md (min-width: 30rem) and (max-width: 47.999rem);
 @custom-media --breakpoint-md (min-width: 48rem);
-@custom-media --breakpoint-md-lg (min-width: 48rem) and (max-width: 64rem);
+@custom-media --breakpoint-md-lg (min-width: 48rem) and (max-width: 63.999rem);
 @custom-media --breakpoint-lg (min-width: 64rem);


### PR DESCRIPTION
Breakpoint classes defined here are overlapping, causing wonky behavior at screen widths exactly lining up withe the breakpoints.

I also added a line to the dev server to serve `/css` files.